### PR TITLE
add mod_cluster_config porcelain type

### DIFF
--- a/manifests/resource/mod_cluster_config.pp
+++ b/manifests/resource/mod_cluster_config.pp
@@ -1,0 +1,57 @@
+# == Defines jboss_admin::resource::mod_cluster_config
+#
+# Configures the mod-cluster-config subsystem.
+#
+# === Parameters
+#
+# [*proxy_list*]
+#   Defines the list of mod cluster proxies to connect to.
+#   Required.
+#
+# [*connector*]
+#   The connector to connect to the mod cluster proxies with.
+#   Valid values are: [ajp, http, https]
+#   Required.
+#
+# [*balanacer*]
+#   The name of the balancer on the mod cluster proxies to assoicate with.
+#   Required.
+#
+define jboss_admin::resource::mod_cluster_config (
+  $server,
+  $proxy_list = undef,
+  $connector  = undef,
+  $balancer   = undef,
+  $ensure     = present,
+  $path       = $name
+) {
+  if $ensure == present {
+    if $proxy_list == undef { fail('The attribute proxy_list is undefined by required') }
+    if $connector == undef { fail('The attribute connector is undefined by required') }
+    if $balancer == undef { fail('The attribute balancer is undefined by required') }
+
+    validate_array($proxy_list)
+    validate_re($connector, [ '^ajp', '^http', '^https']) 
+    validate_string($balancer)
+
+    $raw_options = { 
+      'proxy-list' => join($proxy_list, ','),
+      'connector'  => $connector,
+      'balancer'   => $balancer,
+    }
+    $options = delete_undef_values($raw_options)
+
+    jboss_resource { $path:
+      ensure  => $ensure,
+      server  => $server,
+      options => $options
+    }
+  }
+
+  if $ensure == absent {
+    jboss_resource { $path:
+      ensure => $ensure,
+      server => $server
+    }
+  }
+}


### PR DESCRIPTION
@cpitman I am not positive I did this right so I am hoping for some feedback. Also this porcelain type is different then existing ones because i made it a class rather then a define. I did that because unlike all the others you have, like a logger, this can not be defined more then once in the jboss config so I did not think we should allow it to be defined more then once in puppet. Thoughts on this? 
