### PR TITLE
wrap cli values in double quotes if the value contains spaces or commas

### DIFF
--- a/lib/puppet/util/cli_execution.rb
+++ b/lib/puppet/util/cli_execution.rb
@@ -50,7 +50,8 @@ module Puppet::Util::CliExecution
     if value.is_a?(Array) || value.is_a?(Hash)
       value.inspect
     else
-      value.to_s
+      # if the value contains commas or spaces then wrap it in quotes
+      (/[, ]/ =~ value.to_s).nil? ? value.to_s : "\"#{value.to_s}\""
     end
   end
 


### PR DESCRIPTION
CLI execution fails if a value contains commas, just to be safe I also protect against spaces.

example that fails on setting the cipher_suite:

```
  jboss_admin::resource::ssl { '/subsystem=web/connector=https/ssl=configuration':
    server        => standalone,
    password      => $_nss_password,
    key_alias     => $key_alias,
    keystore_type => 'PKCS11',
    cipher_suite  => 'SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_DSS_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_anon_WITH_AES_128_CBC_SHA,TLS_ECDH_anon_WITH_AES_256_CBC_SHA',
    resource_name => 'https',
    ensure        => $_ensure_https_connector,
  }
```
