### PR TITLE
jboss_admin::cleanup bug fix and enhancment

### DIFF
--- a/manifests/cleanup.pp
+++ b/manifests/cleanup.pp
@@ -1,5 +1,7 @@
 define jboss_admin::cleanup(
-  $server
+  $server,
+  $wait_for_up_tries     = 10,
+  $wait_for_up_try_sleep = 1,
 ) {
   jboss_exec{"Reload Server $name":
     command => ":reload",
@@ -18,8 +20,8 @@ define jboss_admin::cleanup(
   jboss_exec{"Check Server Up After $name":
     command     => ':read-attribute(name=server-state)',
     refreshonly => true,
-    tries       => 10,
-    try_sleep   => 1,
+    tries       => $wait_for_up_tries,
+    try_sleep   => $wait_for_up_try_sleep,
     server      => $server
   }
 }


### PR DESCRIPTION
One bug fix and one enhancement.

need to allow user to override the tries and try sleep in cleanup. The server can take more then 10 seconds to come up some times, especially with a lot of deployed artifacts.
