### PR TITLE
Prefetch all resources from server in single operation

### DIFF
--- a/lib/puppet/util/cli_execution.rb
+++ b/lib/puppet/util/cli_execution.rb
@@ -36,7 +36,7 @@ module Puppet::Util::CliExecution
       return {'outcome' => 'success'} if output =~ /The batch executed successfully/
       return {'outcome' => 'failure', 'failure-description' => output.lines.to_a}
     else
-      json_string = '[' + output.gsub(/ => undefined/, ': null').gsub(/=>/, ':').gsub(/: expression/, ': ').gsub(/\}\n\{/m, "},{").gsub(/\n/, '').gsub(/: (\d+)L/, ': \1') + ']'
+      json_string = '[' + output.gsub(/ => undefined/, ': null').gsub(/=>/, ':').gsub(/: expression/, ': ').gsub(/\}\n\{/m, "},{").gsub(/\n/, '').gsub(/ (\d+)L/, ' \1').gsub(/\(/, '{').gsub(/\)/, '}') + ']'
       parsed_output = JSON.parse(json_string)
       parsed_output = parsed_output.collect {|o| o.delete_if &delete_nil}
       parsed_output = parsed_output.collect {|o| convert_ints_to_strings o }

--- a/lib/puppet/util/cli_execution.rb
+++ b/lib/puppet/util/cli_execution.rb
@@ -36,7 +36,8 @@ module Puppet::Util::CliExecution
       return {'outcome' => 'success'} if output =~ /The batch executed successfully/
       return {'outcome' => 'failure', 'failure-description' => output.lines.to_a}
     else
-      json_string = '[' + output.gsub(/ => undefined/, ': null').gsub(/=>/, ':').gsub(/: expression/, ': ').gsub(/\}\n\{/m, "},{").gsub(/\n/, '').gsub(/ (\d+)L/, ' \1').gsub(/\(/, '{').gsub(/\)/, '}') + ']'
+      json_string = '[' + output.gsub(/ => undefined/, ': null').gsub(/=>/, ':').gsub(/: expression/, ': ').gsub(/\}\n\{/m, "},{").gsub(/\n/, '').gsub(/ (\d+)L/, ' \1').gsub(/bytes\s*\{([^\}]*)\}/,'"bytes {\1}"') + ']'
+
       parsed_output = JSON.parse(json_string)
       parsed_output = parsed_output.collect {|o| o.delete_if &delete_nil}
       parsed_output = parsed_output.collect {|o| convert_ints_to_strings o }

--- a/lib/puppet/util/path_generator.rb
+++ b/lib/puppet/util/path_generator.rb
@@ -20,4 +20,59 @@ class PathGenerator
     }
   end
 
+  # Finds the position in the given root_dump_json of the given CLI path
+  #
+  # path:           CLI path to find in the given root_dump_json
+  # root_dump_json: JSON representation of a root dump of the CLI to search 
+  #
+  # return: the value at the position in the root_dump_json specified by the given CLI path,
+  #         or nil if not found.
+  def self.root_dump_position(path, root_dump_json)
+    # parse the CLI path
+    flattened_path = path.collect{|entry| entry.to_a}.flatten
+
+    # search for the CLI path in the root CLI dump
+    previous_pos = nil 
+    current_pos = root_dump_json
+    flattened_path.each { |step|
+      previous_pos = current_pos
+      current_pos  = current_pos[step]
+
+      # if address not found, check the level above for a 'configuration' namespace
+      #   
+      # Examples:
+      #   CLI address: /subsystem=web/virtual-server=default-host/access-log=configuration
+      #   root dump position: subsystem -> web -> virtual-server -> default-host -> access-log
+      if current_pos.nil? && !previous_pos['configuration'].nil?
+        current_pos = previous_pos['configuration'][step]
+      end 
+
+      # if address not found, check the level above for a 'setting' namespace
+      #   
+      # Examples:
+      #   CLI address: /subsystem=web/virtual-server=default-host/access-log=configuration/directory=configuration
+      #   root dump position: subsystem -> web -> virtual-server -> default-host -> access-log -> setting -> directory
+      if current_pos.nil? && !previous_pos['setting'].nil?
+        current_pos = previous_pos['setting'][step]
+      end 
+
+      # if address not found, and this is the last step of the address, and that step is a configuraiton step,
+      # use the previous step
+      #   
+      # Examples:
+      #   CLI address: /subsystem=web/virtual-server=default-host/access-log=configuration
+      #   root dump position: subsystem -> web -> virtual-server -> default-host -> access-log
+      #   
+      #   CLI address: /subsystem=web/virtual-server=default-host/access-log=configuration/directory=configuration
+      #   root dump position: subsystem -> web -> virtual-server -> default-host -> access-log -> setting -> directory
+      if current_pos.nil? && step == 'configuration'
+        current_pos = previous_pos
+      end 
+
+      break if current_pos.nil?
+    }
+
+    current_pos
+  end
+
 end

--- a/tests/plumbing/simple_batch.pp
+++ b/tests/plumbing/simple_batch.pp
@@ -1,0 +1,25 @@
+jboss_admin::server {'main':
+  base_path => '/opt/jboss'
+}
+
+jboss_batch {'Create ExampleDS':
+  server => main,
+  batch  => [
+    { 
+      address => '/subsystem=datasources/data-source=ExampleDS',
+      ensure  => present,
+      options => {
+        'connection-url' => 'jdbc:h2:mem:test;DB_CLOSE_DELAY=-1',
+        'driver-name'    => 'h2',
+        'jndi-name'      => 'java:jboss/datasources/ExampleDS2',
+        'jta'            => true,
+        'user-name'      => 'sa',
+        'password'       => 'sa'
+      }
+    },
+    {
+      command => '/subsystem=datasources/data-source=ExampleDS:enable'
+    }
+  ]
+}
+


### PR DESCRIPTION
This is a performance improvement for the current CLI provider. Instead of doing a read-resource for each resource, it does a single recursive read-resource from the root, and then searches for each resource within the result. I've tested this locally on some simple manifests, and it appears to be working. However, it is a large change to how things work. @itewk can you test if this works for you?

I'm using the quickstart_logging test case to profile this. What I am timing is the length of a run *after all the resources exist*. My expectation is that the exact same amount of time will be shaved off from an initial run. Before the change, it takes 11.5 seconds. After the change it takes 2.7 seconds.

This appears to save roughly .5 seconds per resource.